### PR TITLE
Always land on 20% prize and collect email

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
+        "canvas-confetti": "^1.9.3",
         "next": "15.3.4",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -2849,6 +2850,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/canvas-confetti": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/canvas-confetti/-/canvas-confetti-1.9.3.tgz",
+      "integrity": "sha512-rFfTURMvmVEX1gyXFgn5QMn81bYk70qa0HLzcIOSVEyl57n6o9ItHeBtUSWdvKAPY0xlvBHno4/v3QPrT83q9g==",
+      "license": "ISC",
+      "funding": {
+        "type": "donate",
+        "url": "https://www.paypal.me/kirilvatev"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
+    "canvas-confetti": "^1.9.3",
     "next": "15.3.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/pages/api/submit-email.js
+++ b/pages/api/submit-email.js
@@ -1,0 +1,8 @@
+export default function handler(req, res) {
+  if (req.method === 'POST') {
+    const { email } = req.body;
+    console.log('Received email for reward:', email);
+    return res.status(200).json({ ok: true });
+  }
+  res.status(405).json({ error: 'Method not allowed' });
+}

--- a/pages/wheel-demo.js
+++ b/pages/wheel-demo.js
@@ -1,22 +1,44 @@
 import Image from "next/image";
 import { useState } from "react";
+import confetti from "canvas-confetti";
 
 export default function WheelDemo() {
   const FINAL_OFFSET = 22.5;
   const [rotation, setRotation] = useState(0);
   const [spinning, setSpinning] = useState(false);
+  const [showForm, setShowForm] = useState(false);
+  const [email, setEmail] = useState("");
+  const [submitted, setSubmitted] = useState(false);
 
   const handleSpin = () => {
     if (spinning) return;
-    const spins = Math.floor(Math.random() * 3) + 3; // 3–5 full turns
+    const spins = 4; // deterministic spins
     const currentAngle = rotation % 360;
     const neededOffset = FINAL_OFFSET - currentAngle;
     setRotation((prev) => prev + spins * 360 + neededOffset);
     setSpinning(true);
+    setShowForm(false);
+    setSubmitted(false);
   };
 
   const handleTransitionEnd = () => {
     setSpinning(false);
+    confetti({ particleCount: 150, spread: 70, origin: { y: 0.4 } });
+    setShowForm(true);
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      await fetch("/api/submit-email", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email }),
+      });
+      setSubmitted(true);
+    } catch (err) {
+      console.error(err);
+    }
   };
 
   const wheelSize = 320;
@@ -85,6 +107,47 @@ export default function WheelDemo() {
       >
         {spinning ? "Spinning..." : "Spin"}
       </button>
+
+      {showForm && (
+        <div style={{ marginTop: 24 }}>
+          {submitted ? (
+            <p style={{ fontWeight: 600 }}>Check your inbox for your coupon!</p>
+          ) : (
+            <form onSubmit={handleSubmit} style={{ display: "flex", flexDirection: "column", alignItems: "center" }}>
+              <p style={{ fontWeight: 700, marginBottom: 10 }}>You won 20% off!</p>
+              <input
+                type="email"
+                required
+                placeholder="Enter your email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                style={{
+                  padding: "8px 12px",
+                  fontSize: 15,
+                  borderRadius: 6,
+                  border: "1px solid #ccc",
+                  marginBottom: 10,
+                  width: 220,
+                }}
+              />
+              <button
+                type="submit"
+                style={{
+                  padding: "8px 16px",
+                  background: "#2962ff",
+                  color: "#fff",
+                  border: "none",
+                  borderRadius: 6,
+                  cursor: "pointer",
+                  fontSize: 15,
+                }}
+              >
+                Send Reward
+              </button>
+            </form>
+          )}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add `canvas-confetti` for visual celebration
- update wheel demo to always land on 20% off
- show an email capture form after spinning and send to simple API
- create `/api/submit-email` endpoint

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_6860713b21ec832284f4f63c8836430c